### PR TITLE
Add SummaryOnly option for concise pslint output

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ $scriptBlock = {
     $myArray | Out-Null
 }
 pslint -ScriptBlock $scriptBlock
+
+# Display only the summary information
+pslint -Path 'C:\path\to\your-script.ps1' -SummaryOnly
 ```
 
 **Example Output:**

--- a/Tests/SummaryOnly.Tests.ps1
+++ b/Tests/SummaryOnly.Tests.ps1
@@ -1,0 +1,15 @@
+# Validate that the SummaryOnly switch suppresses detailed output
+function Test-SummaryOnlySwitch
+{
+    # Arrange
+    Import-Module ../pslint.psm1 -Force
+    $scriptBlock = { Write-Host "Test" }
+
+    # Act
+    $output = pslint -ScriptBlock $scriptBlock -SummaryOnly
+    $joined = $output -join "`n"
+
+    # Assert
+    $joined | Should -Match 'Total Issues Found'
+    $joined | Should -Not -Match 'Code:'
+}

--- a/pslint.psm1
+++ b/pslint.psm1
@@ -36,7 +36,10 @@ function pslint {
 
         [Parameter(ParameterSetName = 'ScriptBlock')]
         [scriptblock]
-        $ScriptBlock
+        $ScriptBlock,
+
+        [switch]
+        $SummaryOnly
     )
 
     BEGIN {
@@ -342,10 +345,12 @@ function pslint {
                 $issueCount = $report.Summary.Categories[$category]
                 if ($issueCount -gt 0) {
                     Write-Output "`n== $category ($issueCount issues) =="
-                    foreach ($issue in $report.Details[$category]) {
-                        Write-Output "  Line $($issue.Line):"
-                        Write-Output "    Code: $($issue.Text)"
-                        Write-Output "    Suggestion: $($issue.Suggestion)"
+                    if (-not $SummaryOnly) {
+                        foreach ($issue in $report.Details[$category]) {
+                            Write-Output "  Line $($issue.Line):"
+                            Write-Output "    Code: $($issue.Text)"
+                            Write-Output "    Suggestion: $($issue.Suggestion)"
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- add `SummaryOnly` switch to pslint
- skip issue details when the switch is used
- document the switch in the README usage section
- add a small test that validates SummaryOnly output

## Testing
- `Invoke-Pester -Path ./Tests -CI`

------
https://chatgpt.com/codex/tasks/task_e_685618b60f34832f8f9139eb4ebeace3