### PR TITLE
Add rule docs and custom rule usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@
       </ul>
     </li>
     <li><a href="#usage">Usage</a></li>
+    <li><a href="#custom-rules">Custom Rules</a></li>
+    <li><a href="#rule-reference">Rule Reference</a></li>
     <li><a href="#roadmap">Roadmap</a></li>
     <li><a href="#contributing">Contributing</a></li>
     <li><a href="#license">License</a></li>
@@ -87,7 +89,7 @@
 - Reducing execution time for Azure Functions and Runbooks.
 - Improving the performance of resource-intensive modules.
 
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
+
 
 ### Features
 
@@ -102,6 +104,7 @@
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
+## Custom Rules
 <!-- GETTING STARTED -->
 
 ## Getting Started
@@ -119,7 +122,6 @@ Install-Module -Name pslint -Repository PSGallery -Scope CurrentUser
 Import-Module pslint
 ```
 
-<p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 <!-- USAGE EXAMPLES -->
 
@@ -215,6 +217,24 @@ pslint -ScriptBlock $scriptBlock
 ```
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
+
+## Custom Rules
+
+`pslint` can also evaluate rules provided in your own modules. Export your rule functions and specify their paths in a ScriptAnalyzer settings file:
+
+```powershell
+$settings = @{
+    CustomRulePath = '.\\MyRules'
+    IncludeRules   = 'Measure-*'
+}
+Invoke-ScriptAnalyzer -Path .\script.ps1 -Settings $settings
+```
+
+In Visual Studio Code set "powershell.scriptAnalysis.settingsPath" to the settings file so custom rules run automatically.
+
+## Rule Reference
+
+For details on the built-in rules and examples of recommended fixes see [docs/rules_overview.md](docs/rules_overview.md).
 
 <!-- ROADMAP -->
 

--- a/docs/rules_overview.md
+++ b/docs/rules_overview.md
@@ -1,0 +1,97 @@
+# PSLint Rule Reference
+
+This document summarizes the built-in performance rules that `pslint` checks. Each section describes the issue being detected and provides a brief code example.
+
+## Output Suppression
+Avoid using `Out-Null` or assigning to `$null` to suppress output.
+
+```powershell
+# Bad
+Get-Process | Out-Null
+
+# Good
+[void](Get-Process)
+```
+
+## Array Addition
+Appending to arrays with `+=` creates a new array each time.
+
+```powershell
+# Bad
+$items = @()
+1..10 | ForEach-Object { $items += $_ }
+
+# Good
+$items = [System.Collections.Generic.List[int]]::new()
+1..10 | ForEach-Object { $items.Add($_) }
+```
+
+## String Addition
+Repeated string concatenation can be slow.
+
+```powershell
+# Bad
+$msg = ""
+1..5 | ForEach-Object { $msg += $_ }
+
+# Good
+$msg = [System.Text.StringBuilder]::new()
+1..5 | ForEach-Object { [void]$msg.Append($_) }
+$msg.ToString()
+```
+
+## Large File Processing
+Avoid loading large files entirely into memory.
+
+```powershell
+# Bad
+$content = Get-Content -Path big.log
+
+# Good
+Get-Content -Path big.log -ReadCount 100 | ForEach-Object {
+    # process lines
+}
+```
+
+## Large Collection Lookup
+Hashtables may be slow for huge collections.
+
+```powershell
+# Consider using a generic dictionary for very large lookups
+$dict = [System.Collections.Generic.Dictionary[string,int]]::new()
+```
+
+## Write-Host Usage
+Prefer `Write-Output` or logging cmdlets for script output.
+
+```powershell
+# Bad
+Write-Host "Finished"
+
+# Good
+Write-Output "Finished"
+```
+
+## Large Loops
+Extremely large loops can hurt performance. Optimize or use .NET methods when possible.
+
+## Repeated Function Calls
+Avoid calling the same function in tight loops with identical parameters. Cache results if possible.
+
+## Cmdlet Pipeline Wrapping
+Filtering with `Where-Object` after a cmdlet can be slower than using a native `-Filter` parameter.
+
+```powershell
+# Bad
+Get-Service | Where-Object Name -eq 'Spooler'
+
+# Good
+Get-Service -Name 'Spooler'
+```
+
+## Dynamic Object Creation
+Creating `[PSCustomObject]` objects inside loops may slow down execution. Consider defining a class for large datasets.
+
+## EnhancedSecretManagementRule
+Checks for insecure secret handling practices such as plain text passwords or insecure `Read-Host` usage.
+


### PR DESCRIPTION
## Summary
- document built-in rule descriptions with examples
- explain how to configure custom rules via ScriptAnalyzer

## Testing
- `Invoke-Pester -Output Detailed`

------
https://chatgpt.com/codex/tasks/task_e_685618e5c8a4832f8013b42b870c1eea