### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/PSCI.yml
+++ b/.github/workflows/PSCI.yml
@@ -1,4 +1,7 @@
 name: PSCI
+permissions:
+  contents: read
+  packages: write
 
 on:
   push:

--- a/.github/workflows/gitguardian.yaml
+++ b/.github/workflows/gitguardian.yaml
@@ -2,6 +2,9 @@ name: GitGuardian scan
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   scanning:
     name: GitGuardian scan


### PR DESCRIPTION
Potential fix for [https://github.com/Calvindd2f/pslint/security/code-scanning/2](https://github.com/Calvindd2f/pslint/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will define the minimal permissions required for the workflow to function. Based on the steps in the workflow, the following permissions are likely needed:
- `contents: read` for accessing the repository's contents.
- `packages: write` for publishing the PowerShell module to the PowerShell Gallery.

The `permissions` block will be added immediately after the `name` field in the workflow file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
